### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/spacecodee/springbootsecurityopentemplate/security/config/HttpSecurityConfig.java
+++ b/src/main/java/com/spacecodee/springbootsecurityopentemplate/security/config/HttpSecurityConfig.java
@@ -37,7 +37,6 @@ public class HttpSecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .with(this.securityHeadersConfigurer, Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
Potential fix for [https://github.com/spacecodee/springboot-security-open-template/security/code-scanning/1](https://github.com/spacecodee/springboot-security-open-template/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `HttpSecurityConfig` class. This involves removing the line that disables CSRF protection and allowing Spring Security to use its default CSRF protection mechanism. This change should be made in the `securityFilterChain` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
